### PR TITLE
fix: allow OpenAPI specs without schemas

### DIFF
--- a/src/mahou/parsers/openapi.py
+++ b/src/mahou/parsers/openapi.py
@@ -43,7 +43,8 @@ class OpenAPIParser(Parser[Server]):
             schemas={},
         )
 
-        server.schemas = self.schemas_from_json(input["components"]["schemas"])
+        components = input.get("components", {})
+        server.schemas = self.schemas_from_json(components.get("schemas", {}))
         server.paths = self.paths_from_json(input["paths"])
 
         return server


### PR DESCRIPTION
Summary
- Allow parsing OpenAPI documents that omit `components.schemas`.
- Keep the parsed schema map empty while still parsing paths.

Validation
- `uv run python -c 'from mahou.parsers.openapi import OpenAPIParser; import json; spec={"openapi":"3.1.0","info":{"title":"Minimal","version":"1.0.0"},"paths":{"/health":{"get":{"operationId":"getHealth","responses":{"200":{"description":"OK"}}}}}}; parsed=OpenAPIParser().parse(json.dumps(spec)); assert parsed.schemas == {}; assert parsed.paths[0].endpoint == "/health"; assert parsed.paths[0].requests[0].operation_id == "getHealth"'`
- `git diff --check`
